### PR TITLE
feat: redesign estimator

### DIFF
--- a/assets/js/estimator.js
+++ b/assets/js/estimator.js
@@ -1,16 +1,165 @@
 (function(){
-  const rateTech={FDM:8,SLA:68,SLS:105};
-  const kMaterial={PLA:1,ABS:1.1,PETG:1.2,Resin:1.3};
-  const kLayer={'0.1':1.2,'0.2':1,'0.3':0.8};
-  let tech='FDM',material='PLA',layer='0.2',vol=50,infill=20,rush=false;
-  const priceEl=document.getElementById('price');
+  const est=document.getElementById('estimator');
+  if(!est) return;
+
+  // Основные коэффициенты расчёта
+  const COEFS={
+    tech:{
+      FDM:{rate_cm3_time:0.04, hourly:350, setup:150, min_order:400}, // FDM настройки
+      SLA:{rate_cm3_time:0.06, hourly:700, setup:300, min_order:800}, // SLA настройки
+      SLS:{rate_cm3_time:0.05, hourly:900, setup:500, min_order:1500} // SLS настройки
+    },
+    layer:{
+      FDM:{"0.3":0.8,"0.2":1.0,"0.1":1.6},
+      SLA:{"0.1":1.0,"0.05":1.7},
+      SLS:{"0.15":1.0,"0.1":1.3}
+    },
+    material:{
+      PLA:{density:1.24,cost_g:1.8,k:1.0,tech:["FDM"]},
+      ABS:{density:1.04,cost_g:2.0,k:1.1,tech:["FDM"]},
+      PETG:{density:1.27,cost_g:2.2,k:1.1,tech:["FDM"]},
+      Resin:{density:1.10,cost_g:6.0,k:1.6,tech:["SLA"]},
+      PA12:{density:1.01,cost_g:5.0,k:1.5,tech:["SLS"]},
+      TPU:{density:1.21,cost_g:2.8,k:1.2,tech:["FDM"]}
+    },
+    support:{none:0,light:80,normal:150,heavy:300},
+    post:{none:0,sand:0.15,paint:0.35},
+    shell_k_approx:0.12
+  };
+
+  // режим ввода
+  let mode='volume';
+  const modeBtns=document.querySelectorAll('.mode');
+  const modeBlocks={
+    volume:document.getElementById('mode-volume'),
+    dims:document.getElementById('mode-dims'),
+    weight:document.getElementById('mode-weight')
+  };
+  modeBtns.forEach(btn=>btn.addEventListener('click',()=>{
+    mode=btn.dataset.mode;
+    modeBtns.forEach(b=>b.classList.remove('active'));
+    btn.classList.add('active');
+    Object.values(modeBlocks).forEach(b=>b.hidden=true);
+    modeBlocks[mode].hidden=false;
+    calc();
+  }));
+
+  // технология
+  let tech='FDM';
+  const techBtns=document.querySelectorAll('.tech');
+  techBtns.forEach(btn=>btn.addEventListener('click',()=>{
+    tech=btn.dataset.tech;
+    techBtns.forEach(b=>b.classList.remove('active'));
+    btn.classList.add('active');
+    populateMaterials();
+    populateLayers();
+    calc();
+  }));
+
+  const materialEl=document.getElementById('material');
+  const layerEl=document.getElementById('layer');
+
+  function populateMaterials(){
+    materialEl.innerHTML='';
+    for(const name in COEFS.material){
+      const m=COEFS.material[name];
+      if(m.tech.includes(tech)){
+        const o=document.createElement('option');
+        o.value=name;o.textContent=name;materialEl.appendChild(o);
+      }
+    }
+  }
+  function populateLayers(){
+    layerEl.innerHTML='';
+    for(const l in COEFS.layer[tech]){
+      const o=document.createElement('option');
+      o.value=l;o.textContent=l;layerEl.appendChild(o);
+    }
+  }
+
+  // элементы формы
+  const volumeEl=document.getElementById('volume');
+  const weightEl=document.getElementById('weight');
+  const dimxEl=document.getElementById('dimx');
+  const dimyEl=document.getElementById('dimy');
+  const dimzEl=document.getElementById('dimz');
+  const formEl=document.getElementById('form');
+  const shellEl=document.getElementById('shell');
+  const infillEl=document.getElementById('infill');
+  const supportEl=document.getElementById('support');
+  const postEl=document.getElementById('post');
+  const qtyEl=document.getElementById('qty');
+  const rushEl=document.getElementById('rush');
+  const price1El=document.getElementById('price1');
+  const pricetotalEl=document.getElementById('pricetotal');
+  const timeEl=document.getElementById('time');
+  const breakdownEl=document.getElementById('breakdown');
+
   function rf(n){return n.toLocaleString('ru-RU');}
-  function calc(){const price=vol*rateTech[tech]*kMaterial[material]*kLayer[layer]*(1+infill/100)*(rush?1.3:1);priceEl.textContent=`≈ ${rf(Math.round(price))} ₽`;logger?.log('calc_change',{tech,material,layer,vol,infill,rush});}
-  document.querySelectorAll('[data-tech]').forEach(btn=>btn.addEventListener('click',()=>{tech=btn.dataset.tech;document.querySelectorAll('[data-tech]').forEach(b=>b.classList.remove('active'));btn.classList.add('active');calc();}));
-  document.getElementById('material').addEventListener('change',e=>{material=e.target.value;calc();});
-  document.getElementById('layer').addEventListener('change',e=>{layer=e.target.value;calc();});
-  document.getElementById('vol').addEventListener('input',e=>{vol=+e.target.value;document.getElementById('volv').textContent=vol;calc();});
-  document.getElementById('infill').addEventListener('input',e=>{infill=+e.target.value;document.getElementById('infillv').textContent=infill;calc();});
-  document.getElementById('rush').addEventListener('change',e=>{rush=e.target.checked;calc();});
+
+  function getDensity(){
+    const m=COEFS.material[materialEl.value];
+    return m?m.density:1;
+  }
+
+  function calcVolume(){
+    if(mode==='volume') return +volumeEl.value||0;
+    if(mode==='weight') return (+weightEl.value||0)/getDensity();
+    if(mode==='dims'){
+      const x=+dimxEl.value||0,y=+dimyEl.value||0,z=+dimzEl.value||0;
+      const box=x*y*z/1000; // мм^3 → см^3
+      const wall=+shellEl.value||0;
+      const shell=COEFS.shell_k_approx*Math.pow(box,2/3)*(wall/10);
+      const effInfill=formEl.value==='solid'?100:(+infillEl.value||0);
+      const inf=(effInfill/100)*(box-shell);
+      return shell+inf;
+    }
+    return 0;
+  }
+
+  function calc(){
+    const density=getDensity();
+    const volume=calcVolume();
+    const weight=volume*density;
+
+    if(mode!=='volume') volumeEl.value=volume.toFixed(2);
+    if(mode!=='weight') weightEl.value=weight.toFixed(1);
+
+    const mat=COEFS.material[materialEl.value];
+    const techCfg=COEFS.tech[tech];
+    const layerK=COEFS.layer[tech][layerEl.value];
+    const time_h=volume*techCfg.rate_cm3_time*layerK;
+    const material_cost=weight*mat.cost_g*mat.k;
+    const machine_cost=time_h*techCfg.hourly;
+    const support_cost=COEFS.support[supportEl.value];
+    const post_cost=(material_cost+machine_cost)*COEFS.post[postEl.value];
+    const setup_cost=techCfg.setup;
+    const subtotal=material_cost+machine_cost+support_cost+post_cost+setup_cost;
+    const qty=+qtyEl.value||1;
+    const total_pre=Math.ceil(subtotal*qty*(rushEl.checked?1.3:1)/10)*10;
+    const minTotal=techCfg.min_order*qty;
+    const total=Math.max(total_pre,minTotal);
+    const price1=total/qty;
+
+    const baseDays=Math.max(1,Math.ceil(time_h/8));
+    const standardDays=baseDays+1;
+    const rushDays=Math.max(1,Math.ceil(baseDays/2));
+
+    price1El.textContent=`≈ ${rf(Math.round(price1))} ₽`;
+    pricetotalEl.textContent=`≈ ${rf(Math.round(total))} ₽`;
+    timeEl.textContent=`${standardDays} дн / срочно: ${rushDays} дн`;
+
+    breakdownEl.innerHTML=`\n<li>Материал: ${rf(Math.round(material_cost))} ₽</li>\n<li>Время станка: ${rf(Math.round(machine_cost))} ₽</li>\n<li>Поддержки: ${rf(Math.round(support_cost))} ₽</li>\n<li>Постобработка: ${rf(Math.round(post_cost))} ₽</li>\n<li>Настройка/старт: ${rf(Math.round(setup_cost))} ₽</li>\n`;
+  }
+
+  [volumeEl,weightEl,dimxEl,dimyEl,dimzEl,formEl,shellEl,infillEl,supportEl,postEl,qtyEl].forEach(el=>el.addEventListener('input',calc));
+  layerEl.addEventListener('change',calc);
+  materialEl.addEventListener('change',calc);
+  rushEl.addEventListener('change',calc);
+  document.getElementById('print').addEventListener('click',()=>window.print());
+
+  populateMaterials();
+  populateLayers();
   calc();
 })();
+

--- a/index.html
+++ b/index.html
@@ -88,48 +88,109 @@
     </section>
 
     <section id="estimator" class="wrap reveal est">
-      <h2 style="font-size:clamp(22px,3vw,28px)">Калькулятор</h2>
+      <h2 style="font-size:clamp(22px,3vw,28px)">Быстрый расчёт 3D‑печати</h2>
       <div class="card pad" style="margin-top:var(--space-6)">
-        <div class="row">
+        <div>
+          <div class="soft" style="font-size:12px">Режим ввода</div>
+          <div style="display:flex;gap:8px;margin-top:6px">
+            <button class="chip mode active" data-mode="volume">объём</button>
+            <button class="chip mode" data-mode="dims">габариты</button>
+            <button class="chip mode" data-mode="weight">вес</button>
+          </div>
+        </div>
+        <div id="mode-volume" class="mode-block" style="margin-top:var(--space-3)">
+          <label class="soft" for="volume">Объём (см³)</label>
+          <input id="volume" type="number" min="0" step="0.1" value="50" />
+        </div>
+        <div id="mode-dims" class="mode-block" hidden style="margin-top:var(--space-3)">
+          <div style="display:grid;gap:16px;grid-template-columns:repeat(auto-fit,minmax(80px,1fr))">
+            <div><label class="soft" for="dimx">X (мм)</label><input id="dimx" type="number" min="1" value="50" /></div>
+            <div><label class="soft" for="dimy">Y (мм)</label><input id="dimy" type="number" min="1" value="50" /></div>
+            <div><label class="soft" for="dimz">Z (мм)</label><input id="dimz" type="number" min="1" value="50" /></div>
+          </div>
+          <div style="margin-top:var(--space-3)">
+            <label class="soft" for="form">Форма</label>
+            <select id="form" style="width:100%;margin-top:6px">
+              <option value="solid">Сплошной</option>
+              <option value="hollow">Полый</option>
+            </select>
+          </div>
+        </div>
+        <div id="mode-weight" class="mode-block" hidden style="margin-top:var(--space-3)">
+          <label class="soft" for="weight">Вес (г)</label>
+          <input id="weight" type="number" min="0" step="0.1" value="60" />
+        </div>
+
+        <div style="display:grid;gap:16px;margin-top:var(--space-6);grid-template-columns:repeat(auto-fit,minmax(130px,1fr))">
           <div>
             <div class="soft" style="font-size:12px">Технология</div>
             <div style="display:flex;gap:8px;margin-top:6px">
-              <button class="chip active" data-tech="FDM">FDM</button>
-              <button class="chip" data-tech="SLA">SLA</button>
-              <button class="chip" data-tech="SLS">SLS</button>
+              <button class="chip tech active" data-tech="FDM">FDM</button>
+              <button class="chip tech" data-tech="SLA">SLA</button>
+              <button class="chip tech" data-tech="SLS">SLS</button>
             </div>
           </div>
           <div>
             <label class="soft" style="font-size:12px" for="material">Материал</label>
-            <select id="material" style="width:100%;margin-top:6px">
-              <option>PLA</option>
-              <option>ABS</option>
-              <option>PETG</option>
-              <option>Resin</option>
-            </select>
+            <select id="material" style="width:100%;margin-top:6px"></select>
           </div>
           <div>
             <label class="soft" style="font-size:12px" for="layer">Слой (мм)</label>
-            <select id="layer" style="width:100%;margin-top:6px">
-              <option value="0.1">0.1</option>
-              <option value="0.2" selected>0.2</option>
-              <option value="0.3">0.3</option>
-            </select>
+            <select id="layer" style="width:100%;margin-top:6px"></select>
+          </div>
+          <div>
+            <label class="soft" style="font-size:12px" for="shell">Толщина стенки (мм)</label>
+            <input id="shell" type="number" min="0.4" step="0.1" value="1" />
           </div>
           <div>
             <label class="soft" style="font-size:12px" for="infill">Заполнение (%)</label>
-            <input id="infill" type="range" min="0" max="100" value="20" class="range" />
-            <div class="soft" style="margin-top:6px">Текущее значение: <span id="infillv">20</span>%</div>
+            <input id="infill" type="number" min="0" max="100" step="1" value="20" />
           </div>
           <div>
-            <label class="soft" style="font-size:12px" for="vol">Объём (см³)</label>
-            <input id="vol" type="range" min="1" max="500" value="50" class="range" />
-            <div class="soft" style="margin-top:6px">Текущее значение: <span id="volv">50</span> см³</div>
+            <label class="soft" style="font-size:12px" for="support">Поддержки</label>
+            <select id="support" style="width:100%;margin-top:6px">
+              <option value="none">Нет</option>
+              <option value="light">Лёгкие</option>
+              <option value="normal">Норм</option>
+              <option value="heavy">Тяжёлые</option>
+            </select>
+          </div>
+          <div>
+            <label class="soft" style="font-size:12px" for="post">Постобработка</label>
+            <select id="post" style="width:100%;margin-top:6px">
+              <option value="none">Нет</option>
+              <option value="sand">Шлифовка</option>
+              <option value="paint">Грунт+Покраска</option>
+            </select>
+          </div>
+          <div>
+            <label class="soft" style="font-size:12px" for="qty">Кол-во изделий</label>
+            <input id="qty" type="number" min="1" value="1" />
+          </div>
+          <div style="display:flex;flex-direction:column;justify-content:flex-end">
+            <label class="soft" style="font-size:12px"><input id="rush" type="checkbox"/> Срочно</label>
           </div>
         </div>
-        <div class="summary">
-          <label class="soft" style="display:flex;align-items:center;gap:var(--space-2)"><input id="rush" type="checkbox"/> Срочно (≈ +30%)</label>
-          <div style="text-align:right"><div class="soft" style="font-size:12px">Оценка</div><div id="price" style="font-size:28px;font-weight:600">≈ 400 ₽</div></div>
+
+        <div style="margin-top:var(--space-6)">
+          <div class="soft" style="font-size:12px">Итого сейчас</div>
+          <div id="output" class="summary" style="flex-direction:column;align-items:flex-start;text-align:left;gap:4px">
+            <div>Цена за 1 шт: <span id="price1">—</span></div>
+            <div>Цена всего: <span id="pricetotal">—</span></div>
+            <div>Срок: <span id="time">—</span></div>
+          </div>
+        </div>
+
+        <details style="margin-top:var(--space-3)">
+          <summary>Разбор стоимости</summary>
+          <ul id="breakdown" class="soft" style="font-size:14px;list-style:none;padding:0;margin:var(--space-3) 0 0 0;"></ul>
+        </details>
+
+        <p class="soft" style="font-size:12px;margin-top:var(--space-3)">Расчёт ориентировочный; точное КП — после слайсинга и проверки геометрии.</p>
+
+        <div style="display:flex;gap:var(--space-3);margin-top:var(--space-3);flex-wrap:wrap">
+          <a class="btn btn--primary" href="#contact">Получить точное КП</a>
+          <button id="print" class="btn" type="button">Печать КП</button>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- overhaul #estimator UI for multiple input modes and print parameters
- implement transparent cost formula with configurable coefficients
- add detailed price breakdown and summary output

## Testing
- `node tests/run.js`

------
https://chatgpt.com/codex/tasks/task_e_6897c27f254883338f3581cd6446b689