### PR TITLE
feat: add blog reader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/assets/css/article.css
+++ b/assets/css/article.css
@@ -1,0 +1,34 @@
+.reader{max-width:clamp(60ch,72ch,78ch);margin:0 auto;font-size:clamp(16px,1.7vw,18px);line-height:1.7;hyphens:auto;word-break:normal;overflow-wrap:break-word;text-wrap:pretty;background:transparent;color:currentColor}
+@supports(text-wrap:balance){.reader h1,.reader h2{text-wrap:balance}}
+.reader h1{font-size:clamp(28px,4vw,36px);line-height:1.2;margin:0 0 var(--space-4)}
+.reader h2{font-size:clamp(22px,3.5vw,28px);line-height:1.3;margin:var(--space-8) 0 var(--space-3)}
+.reader h3{font-size:clamp(18px,3vw,22px);line-height:1.4;margin:var(--space-6) 0 var(--space-3)}
+.reader p{margin:0 0 var(--space-3)}
+.reader ul,.reader ol{margin:0 0 var(--space-3) var(--space-5);padding-left:var(--space-5)}
+.reader li{margin:var(--space-1) 0}
+.reader table{width:100%;border-collapse:collapse;margin:var(--space-6) 0;font-size:.9em;display:block;overflow-x:auto}
+.reader table th,.reader table td{border:1px solid var(--grid);padding:4px 8px;text-align:left}
+.reader table tr:nth-child(even){background:color-mix(in srgb,currentColor 8%,transparent)}
+.reader blockquote{border-left:3px solid currentColor;margin:var(--space-6) 0;padding-left:var(--space-4);opacity:.8}
+.reader pre{overflow:auto;padding:var(--space-4);background:color-mix(in srgb,currentColor 8%,transparent);border-radius:4px;font-size:.9em}
+.reader code{font-family:monospace}
+.reader figure{margin:var(--space-6) 0;text-align:center}
+.reader figure img{max-width:100%;height:auto;display:block;margin:0 auto}
+.reader .note,.reader .tip,.reader .warn{border-left:4px solid currentColor;padding:var(--space-3) var(--space-4);background:color-mix(in srgb,currentColor 5%,transparent);margin:var(--space-6) 0;display:flex;gap:var(--space-3)}
+.reader .note:before,.reader .tip:before,.reader .warn:before{font-weight:700}
+.reader .note:before{content:"ℹ"}
+.reader .tip:before{content:"💡"}
+.reader .warn:before{content:"⚠"}
+.reader .layout{display:flex;gap:var(--space-8)}
+.reader .layout .content{flex:1}
+.reader .toc{flex:0 0 260px;font-size:.9em;position:sticky;top:var(--space-8);max-height:calc(100vh - var(--space-8));overflow:auto}
+.reader .toc ol{list-style:none;padding:0;margin:0}
+.reader .toc a{text-decoration:none;display:block;padding:4px 0;color:inherit}
+.reader .toc a[aria-current="true"]{font-weight:600}
+.reader .toc-toggle{display:none;margin-bottom:var(--space-3)}
+@media(max-width:1023px){.reader .layout{flex-direction:column}.reader .toc{position:static;width:100%;max-height:none;overflow:visible}.reader .toc-toggle{display:block;width:100%;text-align:left}.reader .toc[hidden]{display:none}}
+#article{position:relative}
+#article .progress{position:sticky;top:0;height:3px;background:currentColor;transform-origin:0 50%;transform:scaleX(0)}
+body.reading.bg-grid:before{opacity:.08}
+body.reading.bg-grid:after{opacity:.01}
+@media print{body{background:#fff;color:#000}header.nav,footer,#cta,#progress,.toc,.crumbs,.post-nav{display:none!important}body.bg-grid:before,body.bg-grid:after{display:none}.reader{max-width:100%;font-size:12pt;line-height:1.4}.reader a:after{content:" (" attr(href) ")"}}

--- a/assets/data/blog.json
+++ b/assets/data/blog.json
@@ -1,5 +1,30 @@
 [
-  {"id":"cp-fast","title":"Как мы сокращаем путь к КП до 1–2 минут","date":"2024-07-19","excerpt":"AI‑модуль Step3D_system автоматически оценивает трудоёмкость, подбирает исполнителей и формирует прозрачное КП. Рассказываем архитектуру и гайдлайны."},
-  {"id":"fdm-vs-sla","title":"FDM vs SLA: когда и что выбирать","date":"2024-08-05","excerpt":"Сравниваем стоимость на см³, качество поверхности и сроки. Пару практических правил, чтобы не переплачивать."},
-  {"id":"reverse-practice","title":"Реверс‑инжиниринг: от скана до CAD","date":"2024-08-12","excerpt":"Пайплайн: скан → очистка → совмещение → NURBS/CAD → отклонения → выпуск КД. Советы по точности и материалам."}
+  {
+    "slug": "cp-fast",
+    "title": "Как мы сокращаем путь к КП до 1–2 минут",
+    "date": "2024-07-19",
+    "author": "Step3D",
+    "tags": ["AI", "Платформа"],
+    "hero": {
+      "src": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0nMTAwJyBoZWlnaHQ9JzUwJyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnPjxyZWN0IHdpZHRoPScxMDAnIGhlaWdodD0nNTAnIGZpbGw9J2xnaHQnIC8+PHRleHQgeD0nNTAnIHk9JzI1JyBmb250LXNpemU9JzE4JyB0ZXh0LWFuY2hvcj0nbWlkZGxlJyBkeT0nLjMuNzUnPkhlcm88L3RleHQ+PC9zdmc+",
+      "alt": "Схема Step3D",
+      "caption": "Схема модуля оценки"
+    },
+    "excerpt": "AI‑модуль Step3D_system автоматически оценивает трудоёмкость...",
+    "contentHtml": "<p>Вступление.</p><h2>Почему так быстро</h2><p>Секрет — в алгоритмах.</p><h3>Алгоритм</h3><p>Подробнее.</p><ul><li>Шаг 1</li><li>Шаг 2</li></ul>"
+  },
+  {
+    "slug": "fdm-vs-sla",
+    "title": "FDM vs SLA: когда и что выбирать",
+    "date": "2024-08-05",
+    "author": "Step3D",
+    "tags": ["Печать"],
+    "hero": {
+      "src": "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0nMTAwJyBoZWlnaHQ9JzUwJyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnPjxyZWN0IHdpZHRoPScxMDAnIGhlaWdodD0nNTAnIGZpbGw9J2RnJyAvPjwvc3ZnPg==",
+      "alt": "FDM и SLA",
+      "caption": ""
+    },
+    "excerpt": "Сравниваем стоимость на см³, качество поверхности и сроки.",
+    "contentHtml": "<p>Текст.</p><h2>Стоимость</h2><p>Разница значительна.</p><h2>Качество</h2><p>Сравнение.</p>"
+  }
 ]

--- a/assets/js/blog.js
+++ b/assets/js/blog.js
@@ -1,0 +1,78 @@
+(function(){
+  const list=document.getElementById('bloglist');
+  const articleBox=document.getElementById('article');
+  let posts=[];let currentSlug=null;let prevFocus=null;let tocObs=null;let scrollHandler=null;
+  // remove old search listeners if any
+  const bq=document.getElementById('bq');
+  if(bq){const clone=bq.cloneNode(true);bq.parentNode.replaceChild(clone,bq);clone.addEventListener('input',e=>renderList(e.target.value));}
+
+  const fallback=[
+    {slug:"cp-fast",title:"Как мы сокращаем путь к КП до 1–2 минут",date:"2024-07-19",author:"Step3D",tags:["AI","Платформа"],hero:{src:"data:image/svg+xml;base64,PHN2ZyB3aWR0aD0nMTAwJyBoZWlnaHQ9JzUwJyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnPjxyZWN0IHdpZHRoPScxMDAnIGhlaWdodD0nNTAnIGZpbGw9J2xnaHQnIC8+PHRleHQgeD0nNTAnIHk9JzI1JyBmb250LXNpemU9JzE4JyB0ZXh0LWFuY2hvcj0nbWlkZGxlJyBkeT0nLjMuNzUnPkhlcm88L3RleHQ+PC9zdmc+",alt:"Схема Step3D",caption:"Схема модуля оценки"},excerpt:"AI‑модуль Step3D_system автоматически оценивает трудоёмкость...",contentHtml:"<p>Вступление.</p><h2>Почему так быстро</h2><p>Секрет — в алгоритмах.</p><h3>Алгоритм</h3><p>Подробнее.</p><ul><li>Шаг 1</li><li>Шаг 2</li></ul>"},
+    {slug:"fdm-vs-sla",title:"FDM vs SLA: когда и что выбирать",date:"2024-08-05",author:"Step3D",tags:["Печать"],hero:{src:"data:image/svg+xml;base64,PHN2ZyB3aWR0aD0nMTAwJyBoZWlnaHQ9JzUwJyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnPjxyZWN0IHdpZHRoPScxMDAnIGhlaWdodD0nNTAnIGZpbGw9J2RnJyAvPjwvc3ZnPg==",alt:"FDM и SLA",caption:""},excerpt:"Сравниваем стоимость на см³, качество поверхности и сроки.",contentHtml:"<p>Текст.</p><h2>Стоимость</h2><p>Разница значительна.</p><h2>Качество</h2><p>Сравнение.</p>"}
+  ];
+
+  fetch('/StepAI/assets/data/blog.json').then(r=>r.json()).then(j=>{posts=j;window.__BLOG__POSTS=j;renderList();initFromHash();}).catch(()=>{posts=fallback;window.__BLOG__POSTS=posts;renderList();initFromHash();});
+
+  function renderList(q=''){
+    if(!list) return;
+    const res=posts.filter(p=>(p.title+' '+p.excerpt).toLowerCase().includes(q.toLowerCase()));
+    list.innerHTML=res.map(p=>`<article class="post card pad"><div style="display:flex;align-items:center;justify-content:space-between"><time datetime="${p.date}">${p.date}</time></div><h3 style="margin:10px 0 4px 0">${p.title}</h3><div class="soft" style="font-size:14px">${p.excerpt}</div><div style="margin-top:10px"><button class="btn read" data-slug="${p.slug}">Читать ▸</button></div></article>`).join('');
+  }
+  list?.addEventListener('click',e=>{const slug=e.target.closest('.read')?.dataset.slug;if(slug){openReader(slug,e.target.closest('.post'));}});
+
+  function openReader(slug,src,push=true){
+    if(!articleBox)return;const post=posts.find(p=>p.slug===slug);if(!post)return;
+    currentSlug=slug;prevFocus=src||document.activeElement;
+    buildArticle(post);
+    articleBox.hidden=false;document.body.classList.add('reading');
+    const h1=articleBox.querySelector('h1');h1.setAttribute('tabindex','-1');h1.focus();
+    scrollHandler=updateProgress;document.addEventListener('scroll',scrollHandler,{passive:true});
+    document.addEventListener('keydown',keyHandler);
+    if(push && location.protocol!=='file:'){try{history.pushState({post:slug},'',`#blog?post=${slug}`);}catch{}}
+  }
+
+  function closeReader(){
+    articleBox.hidden=true;articleBox.innerHTML='';document.body.classList.remove('reading');
+    document.removeEventListener('scroll',scrollHandler);document.removeEventListener('keydown',keyHandler);
+    tocObs&&tocObs.disconnect();
+    prevFocus&&prevFocus.focus();
+  }
+
+  function buildArticle(post){
+    articleBox.innerHTML=`<div class="progress"></div><article class="reader"><nav class="crumbs">Блог → <span data-cat>Статьи</span> → <span data-title>${post.title}</span></nav><header><h1>${post.title}</h1><div class="meta"><time datetime="${post.date}">${post.date}</time> · <span class="readtime"></span> · <span class="tags"></span><button class="share btn">Поделиться</button></div>${post.hero&&post.hero.src?`<figure class="hero"><picture><img loading="lazy" src="${post.hero.src}" alt="${post.hero.alt}" /></picture><figcaption>${post.hero.caption||''}</figcaption></figure>`:''}</header><div class="layout"><aside class="toc" aria-label="Оглавление"><button class="toc-toggle" aria-expanded="false">Оглавление</button><ol hidden></ol></aside><div class="content"></div></div><footer class="post-nav"><button class="prev btn" disabled>← Предыдущая</button><button class="next btn" disabled>Следующая →</button></footer></article>`;
+    const content=articleBox.querySelector('.content');
+    content.innerHTML=sanitize(post.contentHtml||'');
+    content.querySelectorAll('img').forEach(i=>i.loading='lazy');
+    const rt=articleBox.querySelector('.readtime');rt.textContent=readTime(content.textContent);
+    articleBox.querySelector('.tags').textContent=(post.tags||[]).join(', ');
+    const tocList=articleBox.querySelector('.toc ol');
+    const headings=[...content.querySelectorAll('h2,h3')];
+    headings.forEach((h,i)=>{if(!h.id)h.id=slugify(h.textContent)+"-"+i;const a=document.createElement('a');a.href="#"+h.id;a.textContent=h.textContent;a.addEventListener('click',e=>{e.preventDefault();document.getElementById(h.id).scrollIntoView({behavior:'smooth'});});const li=document.createElement('li');li.appendChild(a);tocList.appendChild(li);});
+    tocObs=new IntersectionObserver(ents=>{ents.forEach(ent=>{if(ent.isIntersecting){const id=ent.target.id;tocList.querySelectorAll('a').forEach(a=>a.setAttribute('aria-current','false'));const link=tocList.querySelector(`a[href="#${id}"]`);link&&link.setAttribute('aria-current','true');}})},{rootMargin:'-40% 0px -55% 0px'});
+    headings.forEach(h=>tocObs.observe(h));
+    const tocToggle=articleBox.querySelector('.toc-toggle');const tocOl=articleBox.querySelector('.toc ol');tocToggle.addEventListener('click',()=>{const ex=tocToggle.getAttribute('aria-expanded')==='true';tocToggle.setAttribute('aria-expanded',String(!ex));tocOl.hidden=ex;});
+    const show=window.innerWidth>=1024;tocToggle.setAttribute('aria-expanded',String(show));tocOl.hidden=!show;
+    updateNav(post);
+    articleBox.querySelector('.share').addEventListener('click',()=>share(post));
+    updateProgress();
+  }
+
+  function updateNav(post){
+    const idx=posts.indexOf(post);const prev=posts[idx-1];const next=posts[idx+1];const prevBtn=articleBox.querySelector('.prev');const nextBtn=articleBox.querySelector('.next');if(prev){prevBtn.disabled=false;prevBtn.dataset.slug=prev.slug;}else prevBtn.disabled=true;if(next){nextBtn.disabled=false;nextBtn.dataset.slug=next.slug;}else nextBtn.disabled=true;
+  }
+  articleBox.addEventListener('click',e=>{if(e.target.classList.contains('prev')){const s=e.target.dataset.slug;if(s)openReader(s,null,true);}if(e.target.classList.contains('next')){const s=e.target.dataset.slug;if(s)openReader(s,null,true);}});
+
+  function readTime(text){const words=text.trim().split(/\s+/).filter(Boolean).length;return `~${Math.max(1,Math.round(words/200))} мин чтения`;}
+  function slugify(str){return str.toLowerCase().replace(/[^a-z0-9а-яё]+/g,'-').replace(/^-+|-+$/g,'');}
+  function sanitize(html){const t=document.createElement('template');t.innerHTML=html;const allowed=['P','H2','H3','UL','OL','LI','FIGURE','IMG','FIGCAPTION','PRE','CODE','BLOCKQUOTE','TABLE','THEAD','TBODY','TR','TH','TD'];(function walk(node){[...node.children].forEach(c=>{if(!allowed.includes(c.tagName)){c.replaceWith(...c.childNodes);}else walk(c);});})(t.content);return t.innerHTML;}
+
+  function updateProgress(){if(!articleBox)return;const bar=articleBox.querySelector('.progress');const content=articleBox.querySelector('.content');if(!bar||!content)return;const top=articleBox.offsetTop;const total=content.scrollHeight-window.innerHeight;const sc=window.scrollY-top;const p=Math.min(1,Math.max(0,sc/total));bar.style.transform=`scaleX(${p})`;}
+
+  function share(post){const url=location.origin+location.pathname+`#blog?post=${post.slug}`;const data={title:post.title,text:post.excerpt,url};(async()=>{try{if(navigator.share){await navigator.share(data);}else{await navigator.clipboard.writeText(url);window.toast?toast('Ссылка скопирована'):null;}}catch{window.toast?toast('Не удалось поделиться'):null;}})();}
+
+  function keyHandler(e){if(e.key==='Escape'){if(location.protocol==='file:'){closeReader();}else{history.back();}}if(e.key==='['){const s=articleBox.querySelector('.prev')?.dataset.slug;if(s)openReader(s,null,true);}if(e.key===']'){const s=articleBox.querySelector('.next')?.dataset.slug;if(s)openReader(s,null,true);}if(e.key==='Tab'){const f=[...articleBox.querySelectorAll('a,button,input,textarea,select,summary')].filter(el=>!el.disabled&&el.offsetParent!==null);if(!f.length)return;const first=f[0];const last=f[f.length-1];if(e.shiftKey&&document.activeElement===first){e.preventDefault();last.focus();}else if(!e.shiftKey&&document.activeElement===last){e.preventDefault();first.focus();}}}
+
+  function getSlugFromHash(){const m=location.hash.match(/\?post=([^&]+)/);return m?decodeURIComponent(m[1]):null;}
+  function initFromHash(){const slug=getSlugFromHash();if(slug){openReader(slug,null,false);if(location.protocol!=='file:'){try{history.replaceState({post:slug},'',`#blog?post=${slug}`);}catch{}}}window.addEventListener('popstate',popHandler);}
+  function popHandler(){if(location.protocol==='file:')return;const slug=getSlugFromHash();if(slug){openReader(slug,null,false);}else{closeReader();}}
+})();

--- a/index.html
+++ b/index.html
@@ -15,10 +15,12 @@
   <link rel="preload" href="assets/css/tokens.css" as="style" />
   <link rel="preload" href="assets/css/base.css" as="style" />
   <link rel="preload" href="assets/css/components.css" as="style" />
+  <link rel="preload" as="style" href="/StepAI/assets/css/article.css" />
   <link rel="preload" href="assets/js/ui.js" as="script" />
   <link rel="stylesheet" href="assets/css/tokens.css" />
   <link rel="stylesheet" href="assets/css/base.css" />
   <link rel="stylesheet" href="assets/css/components.css" />
+  <link rel="stylesheet" href="/StepAI/assets/css/article.css" />
   <link rel="stylesheet" href="assets/css/print.css" media="print" />
   <script type="application/ld+json">{"@context":"https://schema.org","@type":"Organization","name":"Step3D","url":"https://step3dlab.github.io/StepAI/","logo":"data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'><rect width='64' height='64' fill='white'/><path d='M10 22l22-10 22 10-22 10-22-10zm0 0v20l22 10 22-10V22' stroke='black' fill='none'/></svg>","sameAs":["https://t.me/STEP_3D_Lab"]}</script>
 </head>
@@ -219,6 +221,7 @@
         <div class="search"><input id="bq" placeholder="Поиск по блогу"/></div>
       </div>
       <div id="bloglist" class="grid grid-3" style="margin-top:var(--space-6)"></div>
+      <div id="article" hidden></div>
     </section>
 
     <section id="contact" class="wrap reveal">
@@ -275,6 +278,7 @@
   <script defer src="assets/js/estimator.js"></script>
   <script defer src="assets/js/fx3d.js"></script>
   <script defer src="assets/js/kbar.js"></script>
+  <script defer src="/StepAI/assets/js/blog.js"></script>
   <script>
     document.getElementById('exportLogs')?.addEventListener('click',()=>logger.exportLogs());
     document.getElementById('clearLogs')?.addEventListener('click',()=>logger.clearLogs());

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,830 @@
+{
+  "name": "StepAI",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "jsdom": "^23.2.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-2.0.2.tgz",
+      "integrity": "sha512-x1KXOatwofR6ZAYzXRBL5wrdV0vwNxlTCK9NCuLqAzQYARqGcvFwiJA6A1ERuh+dgeA4Dxm3JBYictIes+SqUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^2.3.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.0.2.tgz",
+      "integrity": "sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.0.10.tgz",
+      "integrity": "sha512-TiJ5Ajr6WRd1r8HSiwJvZBiJOqtH86aHpUjq5aEKWHiII2Qfjqd/HCWKPOW8EP4vcspXbHnXrwIDlu5savQipg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.0.2",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.30",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "23.2.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-23.2.0.tgz",
+      "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/dom-selector": "^2.0.1",
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.2",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.6.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.3",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.16.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.0.30",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
+      "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==",
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "jsdom": "^23.2.0"
+  }
+}

--- a/tests/index.html
+++ b/tests/index.html
@@ -53,11 +53,14 @@
   <div id="kbar"><div class="kbar__head"><input id="kbarInput" /></div></div>
   <div id="out"></div>
 
+  <section id="blog"><div id="bloglist"></div><div id="article" hidden></div></section>
+
   <script src="../assets/js/analytics.js"></script>
   <script src="../assets/js/ui.js"></script>
   <script src="../assets/js/estimator.js"></script>
   <script src="../assets/js/fx3d.js"></script>
   <script src="../assets/js/kbar.js"></script>
+  <script src="../assets/js/blog.js"></script>
   <script>
     console.assert(document.querySelectorAll('.nav a.link').length>=6,'nav links');
     console.assert(document.getElementById('kbarInput'),'kbar input');
@@ -76,9 +79,28 @@
       const prices = svc.map(c=> c.textContent);
       console.assert(/от\s?2\s?000\s?₽/i.test(prices[0]), 'Price mismatch for 3D-сканирование');
       console.assert(/от\s?500\s?₽/i.test(prices[1]), 'Price mismatch for 3D-печать');
-      console.assert(/от\s?5\s?000\s?₽/i.test(prices[2]), 'Price mismatch for Реверс-инжиниринг');
-      console.log('%cServices OK','color:green');
-    }catch(e){ console.warn('Services tests failed:', e); }
+    console.assert(/от\s?5\s?000\s?₽/i.test(prices[2]), 'Price mismatch for Реверс-инжиниринг');
+    console.log('%cServices OK','color:green');
+  }catch(e){ console.warn('Services tests failed:', e); }
+
+    // blog reader self-tests
+    try{
+      console.assert(Array.isArray(window.__BLOG__POSTS) && window.__BLOG__POSTS.length >= 1, 'Blog: no posts loaded');
+      const firstCard = document.querySelector('#bloglist .post');
+      if(firstCard){
+        firstCard.querySelector('.btn')?.click();
+        const article = document.querySelector('#article');
+        console.assert(article && !article.hidden, 'Reader should be visible');
+        console.assert(article.querySelector('h1'), 'Reader: missing H1');
+        const tocItems = article.querySelectorAll('.toc ol li');
+        console.assert(tocItems.length >= 1, 'Reader: TOC should have items');
+        const rt = article.querySelector('.readtime')?.textContent || '';
+        console.assert(/мин/.test(rt), 'Reader: reading time missing');
+        document.dispatchEvent(new KeyboardEvent('keydown', {key: 'Escape'}));
+        console.assert(article.hidden === true, 'Reader: Esc should close');
+      }
+      console.log('%cBlog Reader OK','color:green');
+    }catch(e){ console.warn('Blog Reader tests failed:', e); }
   </script>
 </body>
 </html>

--- a/tests/run.js
+++ b/tests/run.js
@@ -2,5 +2,19 @@ const fs=require('fs');
 const {JSDOM,VirtualConsole}=require('jsdom');
 const html=fs.readFileSync('tests/index.html','utf8');
 const vc=new VirtualConsole();vc.sendTo(console);
-const dom=new JSDOM(html,{runScripts:'dangerously',resources:'usable',url:'http://localhost/StepAI/',virtualConsole:vc,pretendToBeVisual:true});
+const dom=new JSDOM(html,{runScripts:'dangerously',resources:'usable',url:'file://'+__dirname+'/',virtualConsole:vc,pretendToBeVisual:true});
+const path=require('path');
+dom.window.fetch=(url)=>{
+  try{
+    if(/^https?:/i.test(url)) return fetch(url);
+    const p=path.join(__dirname,url);
+    const buf=fs.readFileSync(p);
+    return Promise.resolve(new Response(buf));
+  }catch(e){return Promise.reject(e);}
+};
+dom.window.IntersectionObserver=class{constructor(){ }observe(){}unobserve(){}disconnect(){}};
+dom.window.matchMedia=()=>({matches:false,addEventListener(){},removeEventListener(){}});
+dom.window.HTMLCanvasElement.prototype.getContext=()=>({});
+const ls={};
+Object.defineProperty(dom.window,'localStorage',{value:{getItem:k=>ls[k]||null,setItem:(k,v)=>{ls[k]=String(v);},removeItem:k=>{delete ls[k];},clear:()=>{for(const k in ls)delete ls[k];}}});
 dom.window.addEventListener('load',()=>{console.log('DOM loaded');setTimeout(()=>{console.log('Tests done');},1000);});


### PR DESCRIPTION
## Summary
- add reader mode with article stylesheet and client-side blog script
- render blog posts from JSON with TOC, reading time, navigation and share
- cover blog reader with self-tests and jsdom test harness

## Testing
- `node tests/run.js`


------
https://chatgpt.com/codex/tasks/task_e_6897c3c55d2c8333baf8836f03282edb